### PR TITLE
fix: use canonical opm.* entry-point group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio :: Speech",
 ]
 dependencies = [
-    "ovos-plugin-manager>=0.0.11,<3.0.0",
+    "ovos-plugin-manager>=2.4.0a1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
 Homepage = "https://github.com/OpenVoiceOS/ovos-vad-plugin-noise"
 Repository = "https://github.com/OpenVoiceOS/ovos-vad-plugin-noise"
 
-[project.entry-points."ovos.plugin.VAD"]
+[project.entry-points."opm.VAD"]
 "ovos-vad-plugin-noise" = "ovos_vad_plugin_noise:NoiseVAD"
 
 [tool.setuptools]


### PR DESCRIPTION
Modernize the plugin's entry-point group from the deprecated `ovos.plugin.VAD` to the canonical `opm.VAD` (PluginTypes value in ovos-plugin-manager). The loader aliases the old name, but the canonical group is the current standard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VAD plugin registration namespace for improved compatibility with the updated plugin discovery framework standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->